### PR TITLE
Improve curve on surface

### DIFF
--- a/Bowerbird/CurveOnSurface/ConstructCurveOnSurfaceComponent.cs
+++ b/Bowerbird/CurveOnSurface/ConstructCurveOnSurfaceComponent.cs
@@ -1,4 +1,4 @@
-using Bowerbird.Parameters;
+﻿using Bowerbird.Parameters;
 using Grasshopper.Kernel;
 using Rhino.Geometry;
 using System;
@@ -26,7 +26,6 @@ namespace Bowerbird
         protected override void RegisterOutputParams(GH_OutputParamManager pManager)
         {
             pManager.AddParameter(new CurveOnSurfaceParameter(), "Curve on Surface", "C", "", GH_ParamAccess.item);
-            pManager.AddCurveParameter("Curve", "C", "", GH_ParamAccess.item);
         }
 
         protected override void SolveInstance(IGH_DataAccess DA)
@@ -50,7 +49,6 @@ namespace Bowerbird
             // --- Output
 
             DA.SetData(0, curveOnSurface);
-            DA.SetData(1, curveOnSurface.ToCurve(DocumentTolerance()));
         }
 
         protected override Bitmap Icon => Properties.Resources.icon_curve_on_surface_construct;

--- a/Bowerbird/CurveOnSurface/ConstructCurveOnSurfaceComponent.cs
+++ b/Bowerbird/CurveOnSurface/ConstructCurveOnSurfaceComponent.cs
@@ -1,4 +1,4 @@
-﻿using Bowerbird.Parameters;
+using Bowerbird.Parameters;
 using Grasshopper.Kernel;
 using Rhino.Geometry;
 using System;
@@ -26,6 +26,7 @@ namespace Bowerbird
         protected override void RegisterOutputParams(GH_OutputParamManager pManager)
         {
             pManager.AddParameter(new CurveOnSurfaceParameter(), "Curve on Surface", "C", "", GH_ParamAccess.item);
+            pManager.AddCurveParameter("Approximation", "A", "", GH_ParamAccess.item);
         }
 
         protected override void SolveInstance(IGH_DataAccess DA)
@@ -49,6 +50,7 @@ namespace Bowerbird
             // --- Output
 
             DA.SetData(0, curveOnSurface);
+            DA.SetData(1, curveOnSurface.ToCurve(DocumentTolerance()));
         }
 
         protected override Bitmap Icon => Properties.Resources.icon_curve_on_surface_construct;

--- a/Bowerbird/CurveOnSurface/ConstructCurveOnSurfaceComponent.cs
+++ b/Bowerbird/CurveOnSurface/ConstructCurveOnSurfaceComponent.cs
@@ -1,4 +1,4 @@
-﻿using Bowerbird.Parameters;
+using Bowerbird.Parameters;
 using Grasshopper.Kernel;
 using Rhino.Geometry;
 using System;
@@ -13,7 +13,7 @@ namespace Bowerbird
 {
     public class ConstructCurveOnSurfaceComponent : GH_Component
     {
-        public ConstructCurveOnSurfaceComponent() : base("BB Construct CurveOnSurface", "BBCrvOnSrf", "", "Bowerbird", "Curve on Surface")
+        public ConstructCurveOnSurfaceComponent() : base("BB Construct CurveOnSurface", "BBCrvOnSrf", "Beta! Interface might change!", "Bowerbird", "Curve on Surface")
         {
         }
 

--- a/Bowerbird/CurveOnSurface/CurvatureComponent.cs
+++ b/Bowerbird/CurveOnSurface/CurvatureComponent.cs
@@ -12,7 +12,7 @@ namespace Bowerbird
 {
     public class CurvatureComponent : GH_Component
     {
-        public CurvatureComponent() : base("BB Curvature CurveOnSurface", "κ", "", "Bowerbird", "Curve on Surface")
+        public CurvatureComponent() : base("BB Curvature CurveOnSurface", "κ", "Beta! Interface might change!", "Bowerbird", "Curve on Surface")
         {
         }
 

--- a/Bowerbird/CurveOnSurface/CurveOnSurface.cs
+++ b/Bowerbird/CurveOnSurface/CurveOnSurface.cs
@@ -1,4 +1,4 @@
-﻿using Rhino.Geometry;
+using Rhino.Geometry;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -56,23 +56,23 @@ namespace Bowerbird
 
         public Vector3d CurvatureAt(double t)
         {
-            var x_c = Curve.DerivativeAt(t, 2);
-            var u = x_c[0].X;
-            var v = x_c[0].Y;
-            var u1 = x_c[1].X;
-            var v1 = x_c[1].Y;
-            var u2 = x_c[2].X;
-            var v2 = x_c[2].Y;
+            var uv = Curve.DerivativeAt(t, 2);
+            var u = uv[0].X;
+            var v = uv[0].Y;
+            var u1 = uv[1].X;
+            var v1 = uv[1].Y;
+            var u2 = uv[2].X;
+            var v2 = uv[2].Y;
 
-            Surface.Evaluate(u, v, 2, out var _, out var x_s);
-            var su = x_s[0];
-            var sv = x_s[1];
-            var suu = x_s[2];
-            var suv = x_s[3];
-            var svv = x_s[4];
+            Surface.Evaluate(u, v, 2, out var _, out var x);
+            var s10 = x[0];
+            var s01 = x[1];
+            var s20 = x[2];
+            var s11 = x[3];
+            var s02 = x[4];
 
-            var x1 = u1 * su + v1 * sv;
-            var x2 = u2 * su + v2 * sv + Math.Pow(u1, 2) * suu + Math.Pow(v1, 2) * svv + 2 * u1 * v1 * suv;
+            var x1 = u1 * s10 + v1 * s01;
+            var x2 = u2 * s10 + v2 * s01 + Math.Pow(u1, 2) * s20 + Math.Pow(v1, 2) * s02 + 2 * u1 * v1 * s11;
 
             return (x2 * x1.SquareLength - x1 * (x1 * x2)) / Math.Pow(x1.SquareLength, 2);
         }
@@ -88,25 +88,25 @@ namespace Bowerbird
 
         public Vector3d NormalCurvatureAt(double t)
         {
-            var cs = Curve.DerivativeAt(t, 2);
-            var u = cs[0].X;
-            var v = cs[0].Y;
-            var u1 = cs[1].X;
-            var v1 = cs[1].Y;
-            var u2 = cs[2].X;
-            var v2 = cs[2].Y;
+            var uv = Curve.DerivativeAt(t, 2);
+            var u = uv[0].X;
+            var v = uv[0].Y;
+            var u1 = uv[1].X;
+            var v1 = uv[1].Y;
+            var u2 = uv[2].X;
+            var v2 = uv[2].Y;
 
-            Surface.Evaluate(u, v, 2, out var _, out var ss);
-            var su = ss[0];
-            var sv = ss[1];
-            var suu = ss[2];
-            var suv = ss[3];
-            var svv = ss[4];
+            Surface.Evaluate(u, v, 2, out var _, out var x);
+            var s10 = x[0];
+            var s01 = x[1];
+            var s20 = x[2];
+            var s11 = x[3];
+            var s02 = x[4];
 
-            var x1 = u1 * su + v1 * sv;
-            var x2 = suu * Math.Pow(u1, 2) + su * u2 + 2 * suv * u1 * v1 + svv * Math.Pow(v1, 2) + sv * v2;
+            var x1 = u1 * s10 + v1 * s01;
+            var x2 = u2 * s10 + v2 * s01 + Math.Pow(u1, 2) * s20 + Math.Pow(v1, 2) * s02 + 2 * u1 * v1 * s11;
 
-            var n = Vector3d.CrossProduct(su, sv);
+            var n = Vector3d.CrossProduct(s10, s01);
             n.Unitize();
 
             var c = (x2 * x1.SquareLength - x1 * (x1 * x2)) / Math.Pow(x1.SquareLength, 2);
@@ -116,25 +116,25 @@ namespace Bowerbird
 
         public Vector3d GeodesicCurvatureAt(double t)
         {
-            var x_c = Curve.DerivativeAt(t, 2);
-            var u = x_c[0].X;
-            var v = x_c[0].Y;
-            var u1 = x_c[1].X;
-            var v1 = x_c[1].Y;
-            var u2 = x_c[2].X;
-            var v2 = x_c[2].Y;
+            var uv = Curve.DerivativeAt(t, 2);
+            var u = uv[0].X;
+            var v = uv[0].Y;
+            var u1 = uv[1].X;
+            var v1 = uv[1].Y;
+            var u2 = uv[2].X;
+            var v2 = uv[2].Y;
 
-            Surface.Evaluate(u, v, 2, out var _, out var x_s);
-            var su = x_s[0];
-            var sv = x_s[1];
-            var suu = x_s[2];
-            var suv = x_s[3];
-            var svv = x_s[4];
+            Surface.Evaluate(u, v, 2, out var _, out var xyz);
+            var s10 = xyz[0];
+            var s01 = xyz[1];
+            var s20 = xyz[2];
+            var s11 = xyz[3];
+            var s02 = xyz[4];
 
-            var x1 = u1 * su + v1 * sv;
-            var x2 = u2 * su + v2 * sv + Math.Pow(u1, 2) * suu + Math.Pow(v1, 2) * svv + 2 * u1 * v1 * suv;
+            var x1 = u1 * s10 + v1 * s01;
+            var x2 = u2 * s10 + v2 * s01 + Math.Pow(u1, 2) * s20 + Math.Pow(v1, 2) * s02 + 2 * u1 * v1 * s11;
 
-            var b = Vector3d.CrossProduct(Vector3d.CrossProduct(su, sv), x1);
+            var b = Vector3d.CrossProduct(Vector3d.CrossProduct(s10, s01), x1);
             b.Unitize();
 
             var c = (x2 * x1.SquareLength - x1 * (x1 * x2)) / Math.Pow(x1.SquareLength, 2);

--- a/Bowerbird/CurveOnSurface/DeconstructCurveOnSurfaceComponent.cs
+++ b/Bowerbird/CurveOnSurface/DeconstructCurveOnSurfaceComponent.cs
@@ -13,7 +13,7 @@ namespace Bowerbird
 {
     public class DeconstructCurveOnSurfaceComponent : GH_Component
     {
-        public DeconstructCurveOnSurfaceComponent() : base("BB Deconstruct CurveOnSurface", "Deconstruct", "", "Bowerbird", "Curve on Surface")
+        public DeconstructCurveOnSurfaceComponent() : base("BB Deconstruct CurveOnSurface", "Deconstruct", "Beta! Interface might change!", "Bowerbird", "Curve on Surface")
         {
         }
 

--- a/Bowerbird/CurveOnSurface/DeconstructCurveOnSurfaceComponent.cs
+++ b/Bowerbird/CurveOnSurface/DeconstructCurveOnSurfaceComponent.cs
@@ -26,6 +26,7 @@ namespace Bowerbird
         {
             pManager.AddSurfaceParameter("Surface", "S", "", GH_ParamAccess.item);
             pManager.AddCurveParameter("Curve", "C", "", GH_ParamAccess.item);
+            pManager.AddCurveParameter("Approximation", "A", "", GH_ParamAccess.item);
         }
 
         protected override void SolveInstance(IGH_DataAccess DA)
@@ -47,6 +48,7 @@ namespace Bowerbird
 
             DA.SetData(0, surface);
             DA.SetData(1, curve);
+            DA.SetData(2, curveOnSurface.ToCurve(DocumentTolerance()));
         }
 
         protected override Bitmap Icon => Properties.Resources.icon_curve_on_surface_deconstruct;

--- a/Bowerbird/CurveOnSurface/EvaluateComponent.cs
+++ b/Bowerbird/CurveOnSurface/EvaluateComponent.cs
@@ -12,7 +12,7 @@ namespace Bowerbird
 {
     public class EvaluateComponent : GH_Component
     {
-        public EvaluateComponent() : base("BB Evaluate CurveOnSurface", "BBEval", "", "Bowerbird", "Curve on Surface")
+        public EvaluateComponent() : base("BB Evaluate CurveOnSurface", "BBEval", "Beta! Interface might change!", "Bowerbird", "Curve on Surface")
         {
         }
 

--- a/Bowerbird/CurveOnSurface/ExtrudeComponent.cs
+++ b/Bowerbird/CurveOnSurface/ExtrudeComponent.cs
@@ -14,7 +14,7 @@ namespace Bowerbird
 {
     public class ExtrudeComponent : GH_Component
     {
-        public ExtrudeComponent() : base("BB Extrude CurveOnSurface", "Extrude", "", "Bowerbird", "Curve on Surface")
+        public ExtrudeComponent() : base("BB Extrude CurveOnSurface", "Extrude", "Beta! Interface might change!", "Bowerbird", "Curve on Surface")
         {
         }
 

--- a/Bowerbird/CurveOnSurface/GeodesicCurvatureComponent.cs
+++ b/Bowerbird/CurveOnSurface/GeodesicCurvatureComponent.cs
@@ -12,7 +12,7 @@ namespace Bowerbird
 {
     public class GeodesicCurvatureComponent : GH_Component
     {
-        public GeodesicCurvatureComponent() : base("BB Geodesic Curvature CurveOnSurface", "κg", "", "Bowerbird", "Curve on Surface")
+        public GeodesicCurvatureComponent() : base("BB Geodesic Curvature CurveOnSurface", "κg", "Beta! Interface might change!", "Bowerbird", "Curve on Surface")
         {
         }
 

--- a/Bowerbird/CurveOnSurface/GeodesicTorsionComponent.cs
+++ b/Bowerbird/CurveOnSurface/GeodesicTorsionComponent.cs
@@ -12,7 +12,7 @@ namespace Bowerbird
 {
     public class GeodesicTorsionComponent : GH_Component
     {
-        public GeodesicTorsionComponent() : base("BB Geodesic Torsion CurveOnSurface", "τg", "", "Bowerbird", "Curve on Surface")
+        public GeodesicTorsionComponent() : base("BB Geodesic Torsion CurveOnSurface", "τg", "Beta! Interface might change!", "Bowerbird", "Curve on Surface")
         {
         }
 

--- a/Bowerbird/CurveOnSurface/GeodesicTorsionComponent.cs
+++ b/Bowerbird/CurveOnSurface/GeodesicTorsionComponent.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace Bowerbird
 {
-    class GeodesicTorsionComponent : GH_Component
+    public class GeodesicTorsionComponent : GH_Component
     {
         public GeodesicTorsionComponent() : base("BB Geodesic Torsion CurveOnSurface", "τg", "", "Bowerbird", "Curve on Surface")
         {

--- a/Bowerbird/CurveOnSurface/NormalCurvatureComponent.cs
+++ b/Bowerbird/CurveOnSurface/NormalCurvatureComponent.cs
@@ -55,7 +55,7 @@ namespace Bowerbird
             DA.SetData(2, circle);
         }
 
-        protected override Bitmap Icon => null;
+        protected override Bitmap Icon => Properties.Resources.icon_curve_on_surface_normal_curvature;
 
         public override GH_Exposure Exposure => GH_Exposure.secondary;
 

--- a/Bowerbird/CurveOnSurface/NormalCurvatureComponent.cs
+++ b/Bowerbird/CurveOnSurface/NormalCurvatureComponent.cs
@@ -12,7 +12,7 @@ namespace Bowerbird
 {
     public class NormalCurvatureComponent : GH_Component
     {
-        public NormalCurvatureComponent() : base("BB Normal Curvature CurveOnSurface", "κn", "", "Bowerbird", "Curve on Surface")
+        public NormalCurvatureComponent() : base("BB Normal Curvature CurveOnSurface", "κn", "Beta! Interface might change!", "Bowerbird", "Curve on Surface")
         {
         }
 

--- a/Bowerbird/Types/GH_CurveOnSurface.cs
+++ b/Bowerbird/Types/GH_CurveOnSurface.cs
@@ -61,14 +61,6 @@ namespace Bowerbird.Types
 
         public override bool CastTo<Q>(ref Q target)
         {
-            if (typeof(Q) == typeof(GH_Curve))
-            {
-                var curve = m_value.ToCurve(RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
-                var obj = (object)new GH_Curve(curve);
-                target = (Q)obj;
-                return true;
-            }
-
             if (typeof(Q).IsAssignableFrom(m_value.GetType()))
             {
                 var obj = (object)m_value;


### PR DESCRIPTION
**Features**:
- Add `GeodesicTorsion`.
- `DeconstructCurveOnSurface` return also the 3D approximation as a simple Curve.

**Changes:**
- No automatic conversion from CurveOnSurface to Curve anymore to prevent mistakes. Use `DeconstructCurveOnSurface` instead.

**Fix**:
- Missing icon to `NormalCurvature`.