### PR TITLE
Fix missing DLL in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           mkdir -p yak-package/misc
           cp Bowerbird/bin/publish/Bowerbird.gha yak-package/
+          cp Bowerbird/bin/publish/*.dll yak-package/
           cp Bowerbird/dist/manifest.yml yak-package/
           cp README.md yak-package/misc/
           cp LICENSE yak-package/misc/LICENSE.txt


### PR DESCRIPTION
Ensure that all necessary DLL files are included in the release package by copying them to the appropriate directory.